### PR TITLE
Remove day advance direction (backwards isn't very useful), minor clean

### DIFF
--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -204,12 +204,8 @@ void setStickState(int side, int dxVal, int dyVal)
     hiddbgSetHdlsState(controllerHandle, &controllerState);
 }
 
-void dateSkip(int resetTimeAfterSkips, int skipForward, int resetNTP)
+void dateSkip(int resetTimeAfterSkips, int resetNTP)
 {
-    int direction = 1; //Possible utility to roll back time for weather? If neg, roll backwards
-    if(skipForward != 1)
-        direction = direction * -1;
-
     if(origTime == 0)
     {
         Result ot = timeGetCurrentTime(TimeType_UserSystemClock, (u64*)&origTime);
@@ -221,15 +217,14 @@ void dateSkip(int resetTimeAfterSkips, int skipForward, int resetNTP)
     if(R_FAILED(tg))
         fatalThrow(tg);
 
-    time_t advanceTime = curTime + (direction * 86400);
-    Result ts = timeSetCurrentTime(TimeType_NetworkSystemClock, (uint64_t)advanceTime); //Set new time
+    Result ts = timeSetCurrentTime(TimeType_NetworkSystemClock, (uint64_t)(curTime + 86400)); //Set new time
     if(R_FAILED(ts))
         fatalThrow(ts);
 
     resetSkips++;
-    if(resetTimeAfterSkips != 0 && (resetTimeAfterSkips == resetSkips)) //Reset time after # of skips
+    if(resetNTP == 0 && resetTimeAfterSkips != 0 && (resetTimeAfterSkips == resetSkips)) //Reset time after # of skips
         resetTime();
-    if(resetNTP != 0)
+    else if(resetNTP != 0 && resetTimeAfterSkips != 0 && (resetTimeAfterSkips == resetSkips))
         resetTimeNTP();
 }
 
@@ -242,6 +237,7 @@ void resetTime()
             fatalThrow(ct);
     }
 
+    resetSkips = 0;
     struct tm currentTime = *localtime(&curTime);
     struct tm timeReset = *localtime(&origTime);
     timeReset.tm_hour = currentTime.tm_hour;
@@ -250,13 +246,12 @@ void resetTime()
     Result rt = timeSetCurrentTime(TimeType_NetworkSystemClock, mktime(&timeReset));
     if(R_FAILED(rt))
         fatalThrow(rt);
-
-    resetSkips = 0;
 }
 
 void resetTimeNTP()
 {
-    Result ts = timeSetCurrentTime(TimeType_NetworkSystemClock, (uint64_t)ntpGetTime());
+    resetSkips = 0;
+    Result ts = timeSetCurrentTime(TimeType_NetworkSystemClock, ntpGetTime());
     if(R_FAILED(ts))
         fatalThrow(ts);
 }

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -167,21 +167,21 @@ void peek(u8 outData[], u64 offset, u64 size)
     detach();
 }
 
-void click(HidControllerKeys btn)
+void click(HidNpadButton btn)
 {
     initController();
     press(btn);
     svcSleepThread(buttonClickSleepTime * 1e+6L);
     release(btn);
 }
-void press(HidControllerKeys btn)
+void press(HidNpadButton btn)
 {
     initController();
     controllerState.buttons |= btn;
     hiddbgSetHdlsState(controllerHandle, &controllerState);
 }
 
-void release(HidControllerKeys btn)
+void release(HidNpadButton btn)
 {
     initController();
     controllerState.buttons &= ~btn;

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -25,9 +25,9 @@ MetaData getMetaData(void);
 
 void poke(u64 offset, u64 size, u8* val);
 void peek(u8* outData, u64 offset, u64 size);
-void click(HidControllerKeys btn);
-void press(HidControllerKeys btn);
-void release(HidControllerKeys btn);
+void click(HidNpadButton btn);
+void press(HidNpadButton btn);
+void release(HidNpadButton btn);
 void setStickState(int side, int dxVal, int dyVal);
 void dateSkip(int resetTimeAfterSkips, int resetNTP);
 void resetTime();

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -29,6 +29,6 @@ void click(HidControllerKeys btn);
 void press(HidControllerKeys btn);
 void release(HidControllerKeys btn);
 void setStickState(int side, int dxVal, int dyVal);
-void dateSkip(int resetTimeAfterSkips, int skipForward, int resetNTP);
+void dateSkip(int resetTimeAfterSkips, int resetNTP);
 void resetTime();
 void resetTimeNTP();

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -372,9 +372,8 @@ int argmain(int argc, char **argv)
     if(!strcmp(argv[0], "daySkip"))
     {
         int resetTimeAfterSkips = parseStringToInt(argv[1]);
-        int skipForward = parseStringToInt(argv[2]);
-        int resetNTP = parseStringToInt(argv[3]);
-        dateSkip(resetTimeAfterSkips, skipForward, resetNTP);
+        int resetNTP = parseStringToInt(argv[2]);
+        dateSkip(resetTimeAfterSkips, resetNTP);
     }
 
     if(!strcmp(argv[0], "resetTime"))

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -95,7 +95,7 @@ void __appInit(void)
     if (R_FAILED(rc))
         fatalThrow(rc);
     rc = usbCommsInitialize();
-    if (rc)
+    if (R_FAILED(rc))
         fatalThrow(rc);
     rc = socketInitializeDefault();
     if (R_FAILED(rc))
@@ -219,7 +219,7 @@ int argmain(int argc, char **argv)
     {
         if(argc != 2)
             return 0;
-        HidControllerKeys key = parseStringToButton(argv[1]);
+        HidNpadButton key = parseStringToButton(argv[1]);
         click(key);
     }
 
@@ -228,7 +228,7 @@ int argmain(int argc, char **argv)
     {
         if(argc != 2)
             return 0;
-        HidControllerKeys key = parseStringToButton(argv[1]);
+        HidNpadButton key = parseStringToButton(argv[1]);
         press(key);
     }
 
@@ -237,7 +237,7 @@ int argmain(int argc, char **argv)
     {
         if(argc != 2)
             return 0;
-        HidControllerKeys key = parseStringToButton(argv[1]);
+        HidNpadButton key = parseStringToButton(argv[1]);
         release(key);
     }
 
@@ -249,9 +249,9 @@ int argmain(int argc, char **argv)
 
         int side = 0;
         if(!strcmp(argv[1], "LEFT"))
-            side = JOYSTICK_LEFT;
+            side = 0;
         else if(!strcmp(argv[1], "RIGHT"))
-            side = JOYSTICK_RIGHT;
+            side = 1;
         else return 0;
 
         int dxVal = strtol(argv[2], NULL, 0);

--- a/sys-botbase/source/ntp.c
+++ b/sys-botbase/source/ntp.c
@@ -1,0 +1,57 @@
+/* This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+For more information, please refer to <https://unlicense.org>
+Additionally, the ntp_packet struct uses code licensed under the BSD 3-clause. See LICENSE-THIRD-PARTY for more
+information. */
+
+#define _BSD_SOURCE
+
+#include "ntp.h"
+#include <string.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <switch.h>
+#include <sys/socket.h>
+
+time_t ntpGetTime() {
+    static const char* SERVER_NAME = "0.pool.ntp.org";
+    int sockfd = -1;
+    sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    struct hostent* server;
+    server = gethostbyname(SERVER_NAME);
+
+    struct sockaddr_in serv_addr;
+    memset(&serv_addr, 0, sizeof(struct sockaddr_in));
+    serv_addr.sin_family = AF_INET;
+    memcpy((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr_list[0], 4);
+    serv_addr.sin_port = htons(123);
+    connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+
+    ntp_packet packet;
+    memset(&packet, 0, sizeof(ntp_packet));
+    packet.li_vn_mode = (0 << 6) | (4 << 3) | 3;              // LI 0 | Client version 4 | Mode 3
+    packet.txTm_s = htonl(NTP_TIMESTAMP_DELTA + time(NULL));  // Current networktime on the console
+    send(sockfd, (char*)&packet, sizeof(ntp_packet), 0);
+    (size_t)(recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0));
+    packet.txTm_s = ntohl(packet.txTm_s);
+
+    return (time_t)(packet.txTm_s - NTP_TIMESTAMP_DELTA);
+}

--- a/sys-botbase/source/ntp.h
+++ b/sys-botbase/source/ntp.h
@@ -1,0 +1,59 @@
+/* This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+For more information, please refer to <https://unlicense.org>
+Additionally, the ntp_packet struct uses code licensed under the BSD 3-clause. See LICENSE-THIRD-PARTY for more
+information. */
+
+#pragma once
+
+#include <time.h>
+
+#define NTP_TIMESTAMP_DELTA 2208988800ull
+
+/* ------------- BEGIN BSD 3-CLAUSE LICENSED CODE-------------------- */
+// https://www.cisco.com/c/en/us/about/press/internet-protocol-journal/back-issues/table-contents-58/154-ntp.html
+// Struct adapted from https://github.com/lettier/ntpclient , see LICENSE-THIRD-PARTY for more information.
+typedef struct {
+    uint8_t li_vn_mode;  // li: two bits, leap indicator. vn: three bits, protocol version number. mode: three bits,
+                         // client mode.
+
+    uint8_t stratum;    // Stratum level of the local clock.
+    uint8_t poll;       // Maximum interval between successive messages.
+    uint8_t precision;  // Precision of the local clock.
+
+    uint32_t rootDelay;       // Total round trip delay time.
+    uint32_t rootDispersion;  // Max error allowed from primary clock source.
+    uint32_t refId;           // Reference clock identifier.
+
+    uint32_t refTm_s;  // Reference time-stamp seconds.
+    uint32_t refTm_f;  // Reference time-stamp fraction of a second.
+
+    uint32_t origTm_s;  // Originate time-stamp seconds.
+    uint32_t origTm_f;  // Originate time-stamp fraction of a second.
+
+    uint32_t rxTm_s;  // Received time-stamp seconds.
+    uint32_t rxTm_f;  // Received time-stamp fraction of a second.
+
+    uint32_t txTm_s;  // Transmit time-stamp seconds.
+    uint32_t txTm_f;  // Transmit time-stamp fraction of a second.
+} ntp_packet;
+/* ------------- END BSD 3-CLAUSE LICENSED CODE-------------------- */
+
+time_t ntpGetTime();

--- a/sys-botbase/source/util.c
+++ b/sys-botbase/source/util.c
@@ -63,81 +63,81 @@ u8* parseStringToByteBuffer(char* arg, u64* size)
     return buffer;
 }
 
-HidControllerKeys parseStringToButton(char* arg)
+HidNpadButton parseStringToButton(char* arg)
 {
     if (strcmp(arg, "A") == 0)
     {
-        return KEY_A;
+        return HidNpadButton_A;
     }
     else if (strcmp(arg, "B") == 0)
     {
-        return KEY_B;
+        return HidNpadButton_B;
     }
     else if (strcmp(arg, "X") == 0)
     {
-        return KEY_X;
+        return HidNpadButton_X;
     }
     else if (strcmp(arg, "Y") == 0)
     {
-        return KEY_Y;
+        return HidNpadButton_Y;
     }
     else if (strcmp(arg, "RSTICK") == 0)
     {
-        return KEY_RSTICK;
+        return HidNpadButton_StickR;
     }
     else if (strcmp(arg, "LSTICK") == 0)
     {
-        return KEY_LSTICK;
+        return HidNpadButton_StickL;
     }
     else if (strcmp(arg, "L") == 0)
     {
-        return KEY_L;
+        return HidNpadButton_L;
     }
     else if (strcmp(arg, "R") == 0)
     {
-        return KEY_R;
+        return HidNpadButton_R;
     }
     else if (strcmp(arg, "ZL") == 0)
     {
-        return KEY_ZL;
+        return HidNpadButton_ZL;
     }
     else if (strcmp(arg, "ZR") == 0)
     {
-        return KEY_ZR;
+        return HidNpadButton_ZR;
     }
     else if (strcmp(arg, "PLUS") == 0)
     {
-        return KEY_PLUS;
+        return HidNpadButton_Plus;
     }
     else if (strcmp(arg, "MINUS") == 0)
     {
-        return KEY_MINUS;
+        return HidNpadButton_Minus;
     }
     else if (strcmp(arg, "DLEFT") == 0)
     {
-        return KEY_DLEFT;
+        return HidNpadButton_Left;
     }
     else if (strcmp(arg, "DUP") == 0)
     {
-        return KEY_DUP;
+        return HidNpadButton_Up;
     }
     else if (strcmp(arg, "DRIGHT") == 0)
     {
-        return KEY_DRIGHT;
+        return HidNpadButton_Right;
     }
     else if (strcmp(arg, "DDOWN") == 0)
     {
-        return KEY_DDOWN;
+        return HidNpadButton_Down;
     }
     else if (strcmp(arg, "HOME") == 0)
     {
-        return KEY_HOME;
+        return HiddbgNpadButton_Home;
     }
     else if (strcmp(arg, "CAPTURE") == 0)
     {
-        return KEY_CAPTURE;
+        return HiddbgNpadButton_Capture;
     }
-    return KEY_A; //I guess lol
+    return HidNpadButton_A; //I guess lol
 }
 
 Result capsscCaptureForDebug(void *buffer, size_t buffer_size, u64 *size) {

--- a/sys-botbase/source/util.h
+++ b/sys-botbase/source/util.h
@@ -6,5 +6,5 @@ extern bool debugResultCodes;
 
 u64 parseStringToInt(char* arg);
 u8* parseStringToByteBuffer(char* arg, u64* size);
-HidControllerKeys parseStringToButton(char* arg);
+HidNpadButton parseStringToButton(char* arg);
 Result capsscCaptureForDebug(void *buffer, size_t buffer_size, u64 *size);


### PR DESCRIPTION
Showing a lot of additions/deletions, but that's probably due to VS2019 normalizing spaces. Actual changes are limited to L207-L256 in `commands.c`, then arg removal for date/time in `commands.h` and `main.c`